### PR TITLE
Update util.h

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -242,7 +242,7 @@ void runCommand(std::string strCommand);
 
 inline std::string i64tostr(int64 n)
 {
-    return strprintf("%"PRI64d, n);
+    return strprintf("%" PRI64d, n);
 }
 
 inline std::string itostr(int n)


### PR DESCRIPTION
PRI64d now requires separation by a space to avoid a compiler warning.