### PR TITLE
Update main.h

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -931,7 +931,7 @@ public:
             printf("GetStakeEntropyBit: hashSig=%s", hashSig.ToString().c_str());
         hashSig >>= 159; // take the first bit of the hash
         if (fDebug && GetBoolArg("-printstakemodifier"))
-            printf(" entropybit=%"PRI64d"\n", hashSig.Get64());
+            printf(" entropybit=%" PRI64d "\n", hashSig.Get64());
         return hashSig.Get64();
     }
 


### PR DESCRIPTION
PRI64d now requires separation by a space to avoid a compiler warning.